### PR TITLE
Clearer error when serialization is not supported

### DIFF
--- a/lib/pigeon_hole/typed_json.rb
+++ b/lib/pigeon_hole/typed_json.rb
@@ -79,7 +79,7 @@ module PigeonHole
         value.map { |av| serialize_value(av) }
       else
         unless serializer = SERIALIZERS[value.class]
-          raise UnsupportedType.new(value.class)
+          raise UnsupportedType.new("Serialization of #{value.class} is not supported")
         end
 
         serializer.serialize(value)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -109,6 +109,6 @@ describe "serializing custom type" do
   subject { PigeonHole.generate(input) }
 
   it "raises an unsupported type error" do
-    expect { subject }.to raise_error(PigeonHole::TypedJSON::UnsupportedType)
+    expect { subject }.to raise_error(PigeonHole::TypedJSON::UnsupportedType, "Serialization of CustomType is not supported")
   end
 end


### PR DESCRIPTION
Changed the message to be more verbose as just seeing the class name was ambiguous.
